### PR TITLE
fix: adding variable to storybook run command for node 18 users

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "vitest run",
     "test:watch": "vitest watch",
     "coverage": "vitest run --coverage",
-    "storybook": "start-storybook -p 6006",
+    "storybook": "NODE_OPTIONS=--openssl-legacy-provider start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },
   "lint-staged": {


### PR DESCRIPTION
## Describe your changes
Addresses the following error for users running node version 18 and trying to utilize storybook:
![Screen Shot 2023-01-26 at 6 10 32 PM (1)](https://user-images.githubusercontent.com/29721136/215001322-2b068079-d8b9-476a-b2ee-b90c3d4a8f44.png)

## Issue ticket number and link
N/a

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
