### PR TITLE
fix: corrext pill sizing and add btn animation

### DIFF
--- a/src/components/pill/pill.jsx
+++ b/src/components/pill/pill.jsx
@@ -1,19 +1,22 @@
 import cx from "classnames";
+import { motion } from "framer-motion";
 import styled from "styled-components";
 import copyIcon from "../../assets/copy-icon.svg";
 
 /**
  * Pill Component
+ * @author [Shaheen Hadadzadeh](https://github.com/shaheenhad)
  * @param className optional classNames that will be passed to the pill
  * @param shape expects 'round' or 'square'
  * @param isCopiable expects 'true' or 'false'
  * @param text expects the text to be displayed in the pill
  * @param opacity expects the pill background opacity '10' or '20'
  * @param textOpacity expects the text opacity '100' or '70'
+ * @param size 'small' or 'large'
  */
 
 // TODO: Refactor to use common Button Component
-const CopyBtn = styled.button`
+const CopyBtn = styled(motion.button)`
   background-image: url(${copyIcon});
   background-position: center;
   background-repeat: no-repeat;
@@ -30,14 +33,15 @@ export const Pill = ({
   shape,
   opacity,
   textOpacity,
+  size,
 }) => {
   return (
     <div className="d-flex flex-row align-items-center">
       <div
         className={cx(
-          `badge bg-white bg-opacity-${opacity} text-opacity-${textOpacity} text-white fs-14px ${
+          `badge px-8px lh-sm bg-white bg-opacity-${opacity} text-opacity-${textOpacity} text-white fs-12px ${
             shape === "round" ? "rounded-pill" : ""
-          }`,
+          } ${size === "large" ? "py-4px" : "py-2px"}`,
           className
         )}
       >
@@ -46,10 +50,10 @@ export const Pill = ({
       {isCopiable && (
         <CopyBtn
           onClick={() => {
-            // TODO: Add a visual indicator that something was copied
             navigator.clipboard.writeText(text);
           }}
-          className="ms-2"
+          className="ms-8px"
+          whileTap={{ scale: 0.75 }}
         ></CopyBtn>
       )}
     </div>

--- a/src/components/pill/pill.jsx
+++ b/src/components/pill/pill.jsx
@@ -1,5 +1,8 @@
 import cx from "classnames";
 import { motion } from "framer-motion";
+import { useRef, useState } from "react";
+import Overlay from "react-bootstrap/Overlay";
+import Tooltip from "react-bootstrap/Tooltip";
 import styled from "styled-components";
 import copyIcon from "../../assets/copy-icon.svg";
 
@@ -35,9 +38,12 @@ export const Pill = ({
   textOpacity,
   size,
 }) => {
+  const [show, setShow] = useState(false);
+  const target = useRef(null);
   return (
     <div className="d-flex flex-row align-items-center">
       <div
+        ref={target}
         className={cx(
           `badge px-8px lh-sm bg-white bg-opacity-${opacity} text-opacity-${textOpacity} text-white fs-12px ${
             shape === "round" ? "rounded-pill" : ""
@@ -48,13 +54,22 @@ export const Pill = ({
         {text}
       </div>
       {isCopiable && (
-        <CopyBtn
-          onClick={() => {
-            navigator.clipboard.writeText(text);
-          }}
-          className="ms-8px"
-          whileTap={{ scale: 0.75 }}
-        ></CopyBtn>
+        <>
+          <CopyBtn
+            onClick={() => {
+              navigator.clipboard.writeText(text);
+              setShow(true);
+              setTimeout(() => {
+                setShow(false);
+              }, 1500);
+            }}
+            className="ms-8px"
+            whileTap={{ scale: 0.75 }}
+          ></CopyBtn>
+          <Overlay target={target.current} show={show} placement="bottom">
+            {(props) => <Tooltip {...props}>Copied!</Tooltip>}
+          </Overlay>
+        </>
       )}
     </div>
   );

--- a/src/components/pill/pill.stories.jsx
+++ b/src/components/pill/pill.stories.jsx
@@ -5,7 +5,7 @@ export default {
   component: Pill,
   argTypes: {
     className: {
-      options: ["", "fs-16px", "fs-18px"],
+      options: ["", "fs-14px", "fs-16px", "fs-18px"],
       control: { type: "radio" },
     },
     isCopiable: {
@@ -25,6 +25,10 @@ export default {
       options: [100, "70"],
       control: { type: "radio" },
     },
+    size: {
+      options: ["small", "large"],
+      control: { type: "radio" },
+    },
   },
 };
 
@@ -38,4 +42,5 @@ Variants.args = {
   opacity: "20",
   textOpacity: 100,
   shape: "square",
+  size: "small",
 };

--- a/src/theme/custom.scss
+++ b/src/theme/custom.scss
@@ -40,6 +40,7 @@ $font-sizes: (
 $spacer: 4px;
 $spacers: (
   0: 0,
+  "2px": $spacer * 0.5,
   "4px": $spacer * 1,
   "8px": $spacer * 2,
   "12px": $spacer * 3,


### PR DESCRIPTION
## Corrected pill sizing, added button animation for copying to give user confirmation

## [Issue 68](https://github.com/jahorwitz/mu-methods/issues/68)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If there are changes to components, I have added / updated automated tests
- [x] I have made any necessary updates to Storybook to accompany these changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
